### PR TITLE
Add support for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,20 @@ add_feature_info(Asan QCORO_ENABLE_ASAN "Build with AddressSanitizer")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_AUTOMOC ON)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -pedantic")
-
+if (MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX")
+    # Disable warning C5054: operator '&': deprecated between enumerations of different types caused by QtWidgets/qsizepolicy.h
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd5054")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -pedantic")
+endif()
 
 if (QCORO_ENABLE_ASAN)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+    if (MSVC)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fsanitize=address")
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+    endif()
 endif()
 
 include(QCoroMacros.cmake)

--- a/QCoroMacros.cmake
+++ b/QCoroMacros.cmake
@@ -4,7 +4,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcoroutines")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcoroutines-ts -stdlib=libc++")
-else()
+elseif (NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER_ID} is not currently supported.")
 endif()
 

--- a/qcoro/CMakeLists.txt
+++ b/qcoro/CMakeLists.txt
@@ -27,6 +27,7 @@ target_include_directories(QCoro
     INTERFACE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
     PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+set_target_properties(QCoro PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
 
 set(qcoro_HEADERS
     concepts.h

--- a/qcoro/coroutine.h
+++ b/qcoro/coroutine.h
@@ -6,7 +6,7 @@
 #if defined(__clang__)
 #include <experimental/coroutine>
 #define QCORO_STD std::experimental
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) || defined(_MSC_VER)
 #include <coroutine>
 #define QCORO_STD std
 #else

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,8 +41,14 @@ endfunction()
 
 qcoro_add_test(qtimer)
 qcoro_add_test(qnetworkreply LINK_LIBRARIES Qt${QT_VERSION_MAJOR}::Network)
-qcoro_add_dbus_test(qdbuspendingcall LINK_LIBRARIES Qt${QT_VERSION_MAJOR}::DBus)
-qcoro_add_dbus_test(qdbuspendingreply LINK_LIBRARIES Qt${QT_VERSION_MAJOR}::DBus)
+
+include(CheckIncludeFile)
+check_include_file_cxx("sys/wait.h" HAVE_SYS_WAIT_H)
+if (HAVE_SYS_WAIT_H)
+    qcoro_add_dbus_test(qdbuspendingcall LINK_LIBRARIES Qt${QT_VERSION_MAJOR}::DBus)
+    qcoro_add_dbus_test(qdbuspendingreply LINK_LIBRARIES Qt${QT_VERSION_MAJOR}::DBus)
+endif()
+
 if (QT_HAS_COMPAT_ABI)
     qcoro_add_test(qfuture LINK_LIBRARIES Qt${QT_VERSION_MAJOR}::Concurrent)
 endif()

--- a/tests/testobject.h
+++ b/tests/testobject.h
@@ -66,7 +66,7 @@ protected:
         QEventLoop el;
         QTimer::singleShot(5s, &el, [&el]() mutable { el.exit(1); });
 
-        [[maybe_unused]] const auto result = (static_cast<TestClass *>(this)->*testFunction)(el);
+        [[maybe_unused]] const auto unused = (static_cast<TestClass *>(this)->*testFunction)(el);
 
         bool testFinished = el.property("testFinished").toBool();
         const bool shouldNotSuspend = el.property("shouldNotSuspend").toBool();


### PR DESCRIPTION
All tests passed except `qdbuspendingcall`, `qdbuspendingreply` (because `sys/wait.h` absent) and `qcoroprocess` (because `true` and `sleep` absent).
```
$ ctest -C RelWithDebInfo
Test project C:/Users/Richard/Desktop/Dev/qcoro/build
      Start  1: test-qtimer
 1/11 Test  #1: test-qtimer ......................   Passed    0.62 sec
      Start  2: test-qnetworkreply
 2/11 Test  #2: test-qnetworkreply ...............   Passed    3.55 sec
      Start  3: test-qfuture
 3/11 Test  #3: test-qfuture .....................   Passed    0.86 sec
      Start  4: test-qcoroprocess
 4/11 Test  #4: test-qcoroprocess ................***Failed   20.07 sec
      Start  5: test-qcorolocalsocket
 5/11 Test  #5: test-qcorolocalsocket ............   Passed    7.43 sec
      Start  6: test-qcoroabstractsocket
 6/11 Test  #6: test-qcoroabstractsocket .........   Passed    7.59 sec
      Start  7: test-qcoronetworkreply
 7/11 Test  #7: test-qcoronetworkreply ...........   Passed    3.37 sec
      Start  8: test-qcorotcpserver
 8/11 Test  #8: test-qcorotcpserver ..............   Passed    0.55 sec
      Start  9: test-qcorosignal
 9/11 Test  #9: test-qcorosignal .................   Passed    0.32 sec
      Start 10: test-task
10/11 Test #10: test-task ........................   Passed    1.03 sec
      Start 11: test-testhttpserver
11/11 Test #11: test-testhttpserver ..............   Passed    2.63 sec

91% tests passed, 1 tests failed out of 11

Total Test time (real) =  48.08 sec

The following tests FAILED:
          4 - test-qcoroprocess (Failed)
Errors while running CTest
Output from these tests are in: C:/Users/Richard/Desktop/Dev/qcoro/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
```

Sometimes `qcorotcpserver` failed with `ok = false`. I think it's a race condition when data was written into socket but `ok` was not set to true.
By adding `qDebug() << "ok =" << ok;` before `QCORO_VERIFY(ok);`, you can get such output:
```
********* Start testing of QCoroTcpServerTest *********
Config: Using QtTest library 5.15.2, Qt 5.15.2 (x86_64-little_endian-llp64 shared (dynamic) release build; by MSVC 2019), windows 10
PASS   : QCoroTcpServerTest::initTestCase()
PASS   : QCoroTcpServerTest::testWaitForNewConnectionTriggers()
QDEBUG : QCoroTcpServerTest::testDoesntCoAwaitPendingConnection() ok = false
PASS   : QCoroTcpServerTest::testDoesntCoAwaitPendingConnection()
PASS   : QCoroTcpServerTest::cleanupTestCase()
Totals: 4 passed, 0 failed, 0 skipped, 0 blacklisted, 591ms
********* Finished testing of QCoroTcpServerTest *********
```