### PR TITLE
Improve HttpServer-based tests

### DIFF
--- a/tests/qcoronetworkreply.cpp
+++ b/tests/qcoronetworkreply.cpp
@@ -62,6 +62,7 @@ private:
 
     QCoro::Task<> testDoesntCoAwaitNullReply_coro(QCoro::TestContext test) {
         test.setShouldNotSuspend();
+        mServer.setExpectTimeout(true);
 
         QNetworkReply *reply = nullptr;
 


### PR DESCRIPTION
Fail the test on server timeout, allow to prematurely terminate the
server when the test finishes.

This should make the tests faster and more reliable.