### PR TITLE
Make qCoro usable on platforms with missing features

### DIFF
--- a/qcoro/core/qcorocore.h
+++ b/qcoro/core/qcorocore.h
@@ -3,9 +3,12 @@
 // SPDX-License-Identifier: MIT
 
 #include "config.h"
+#include <qglobal.h>
 
 #include "qcoroiodevice.h"
-#include "qcoroprocess.h"
+#if !QT_CONFIG(process)
+#  include "qcoroprocess.h"
+#endif
 #include "qcorosignal.h"
 #include "qcorotimer.h"
 

--- a/qcoro/qcoro.h
+++ b/qcoro/qcoro.h
@@ -4,7 +4,11 @@
 
 #pragma once
 
+#include <qglobal.h>
+
 #include "task.h"
 #include "qcorocore.h"
-#include "qcorodbus.h"
+#if defined(QT_DBUS_LIB)
+#  include "qcorodbus.h"
+#endif
 #include "qcoronetwork.h"


### PR DESCRIPTION
* iOS has no QProcess
* Android has no QtDBus library