### PR TITLE
Fix early return in QCoro::waitFor

### DIFF
--- a/tests/task.cpp
+++ b/tests/task.cpp
@@ -376,6 +376,17 @@ private Q_SLOTS:
         QCOMPARE(result, 42);
     }
 
+    void testEarlyReturnWaitFor() {
+        QCoro::waitFor([]() -> QCoro::Task<> { co_return; }());
+    }
+
+    void testEarlyReturnWaitForWithValue() {
+        const auto result = QCoro::waitFor([]() -> QCoro::Task<int> {
+            co_return 42;
+        }());
+        QCOMPARE(result, 42);
+    }
+
     void testIgnoredVoidTaskResult() {
         QEventLoop el;
         ignoreCoroutineResult(el, [&el]() -> QCoro::Task<> {


### PR DESCRIPTION
Calling exit() on a QEventLoop that hasn't even started does nothing:
it will also not prevent it from being started on exec().