### PR TITLE
cmake: prefer `-pthread` flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ qcoro_enable_coroutines()
 # Dependencies
 #-----------------------------------------------------------#
 
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
 set(REQUIRED_QT_COMPONENTS Core)


### PR DESCRIPTION
ref: https://cmake.org/cmake/help/latest/module/FindThreads.html#variable:THREADS_PREFER_PTHREAD_FLAG

> Use of both the imported target as well as this switch is highly recommended for new code.

See also: [Stack Overflow: Difference between -pthread and -lpthread](https://stackoverflow.com/questions/23250863/difference-between-pthread-and-lpthread-while-compiling)