### PR TITLE
Build: Check if libatomic is needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ add_feature_info(QtNetwork QCORO_WITH_QTNETWORK "Build QtNetwork support")
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
+include(cmake/CheckAtomic.cmake)
+
 set(REQUIRED_QT_COMPONENTS Core)
 if (QCORO_WITH_QTDBUS)
     list(APPEND REQUIRED_QT_COMPONENTS DBus)

--- a/cmake/AddQCoroLibrary.cmake
+++ b/cmake/AddQCoroLibrary.cmake
@@ -96,6 +96,10 @@ function(add_qcoro_library)
     target_link_libraries(${target_name} ${qcoro_LIBS})
     target_link_libraries(${target_name} ${qt_LIBS})
 
+    if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB AND NOT LIB_INTERFACE)
+        target_link_libraries(${target_name} PUBLIC atomic)
+    endif()
+
     set_target_properties(
         ${target_name}
         PROPERTIES

--- a/cmake/CheckAtomic.cmake
+++ b/cmake/CheckAtomic.cmake
@@ -1,0 +1,40 @@
+# std::atomic may need libatomic to function correctly.
+
+INCLUDE(CheckCXXSourceCompiles)
+INCLUDE(CheckLibraryExists)
+
+# Sometimes linking against libatomic is required for atomic ops, if
+# the platform doesn't support lock-free atomics.
+
+function(check_working_cxx_atomics varname)
+  set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
+  CHECK_CXX_SOURCE_COMPILES("
+#include <atomic>
+std::atomic<int> x;
+std::atomic<short> y;
+std::atomic<char> z;
+int main() {
+  ++z;
+  ++y;
+  return ++x;
+}
+" ${varname})
+  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
+endfunction(check_working_cxx_atomics)
+
+# Check for (non-64-bit) atomic operations.
+if(MSVC)
+  set(HAVE_CXX_ATOMICS_WITHOUT_LIB True)
+else()
+  # First check if atomics work without the library.
+  check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITHOUT_LIB)
+  # If not, check if the library exists, and atomics work with it.
+  if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+    list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+    check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITH_LIB)
+    if (NOT HAVE_CXX_ATOMICS_WITH_LIB)
+      message(FATAL_ERROR "Host compiler must support std::atomic!")
+    endif()
+  endif()
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,9 @@ function(qcoro_add_network_test _name)
         Threads::Threads
         ${TEST_LINK_LIBRARIES}
     )
+    if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
+        target_link_libraries(test-${_name} atomic)
+    endif()
     add_test(NAME test-${_name} COMMAND test-${_name})
 endfunction()
 


### PR DESCRIPTION
This fixes build on RISC-V with glibc 2.34+.

The main cause is that since glibc 2.34, there is no need to pass a `-pthread` to use `std::thread`, but `std::atomic` won't work without one of `-pthread` and `-latomic` flag on RISC-V.

`std::atomic` is referenced in file `qcoro/task.h` as `std::atomic<bool> QCoro::detail::TaskPromiseBase::mResumeAwaiter` and `std::atomic<bool> QCoro::detail::TaskPromiseBase::mDestroyHandle`. It's also referenced in `tests/testhttpserver.h` so I linked network tests against `libatomic`, too.

This patch is tested on rv64gc(qemu).