### PR TITLE
Fix build with gcc 11.3.0 (resolves #57)

### DIFF
--- a/qcoro/core/qcorosignal.h
+++ b/qcoro/core/qcorosignal.h
@@ -127,8 +127,7 @@ QCoroSignal(T *, FuncPtr &&, std::chrono::milliseconds) -> QCoroSignal<T, FuncPt
 template<QCoro::detail::concepts::QObject T, typename FuncPtr>
 inline auto qCoro(T *obj, FuncPtr &&ptr, std::chrono::milliseconds timeout)
     -> QCoro::Task<typename QCoro::detail::QCoroSignal<T, FuncPtr>::result_type> {
-    QCoro::detail::QCoroSignal coroSignal(obj, std::forward<FuncPtr>(ptr), timeout);
-    auto result = co_await coroSignal;
+    auto result = co_await QCoro::detail::QCoroSignal(obj, std::forward<FuncPtr>(ptr), timeout);
     co_return std::move(result);
 }
 


### PR DESCRIPTION
QCoro::detail::QCoroSignal is not a copy-constructible class
(it contains std::unique_ptr), but when calling co_await,
gcc tried to make a copy of coroSignal either when evaluating
the expression after `co_await`, or when passing the result of
the expression to `Task<T>::await_transform()`. This is despite
Task::await_transform() having an overload that accepts reference
or an lvalue reference to the object.

I do believe this might be a regression in gcc 11.3, since it worked
in gcc 11.2 and it works with clang as well. The C++ standard does
not specify any constraints regarding how the result of the expression
after the co_await keyword should be passed to `await_transform`.

As a workaround, we co_await a temporary QCoroSignal, which gcc seems
to correctly pass down as a lvalue reference, so no issues with copying.
Explictly `std::move()`ing `coroSignal` to `co_await` would also work,
but it's weird.

I haven't confirmed whether this is a bug yet, as I first need to put
together a small reproducer case.