### PR TITLE
Fix ODR violation when LTO is enabled

### DIFF
--- a/qcoro/network/qcoroabstractsocket.cpp
+++ b/qcoro/network/qcoroabstractsocket.cpp
@@ -11,16 +11,16 @@ using namespace std::chrono_literals;
 
 namespace {
 
-class SocketReadySignalHelper : public WaitSignalHelper {
+class AbstractSocketReadySignalHelper : public WaitSignalHelper {
     Q_OBJECT
 public:
-    explicit SocketReadySignalHelper(const QAbstractSocket *socket, void(QIODevice::*readySignal)())
+    explicit AbstractSocketReadySignalHelper(const QAbstractSocket *socket, void(QIODevice::*readySignal)())
         : WaitSignalHelper(socket, readySignal)
         , mStateChanged(connect(socket, &QAbstractSocket::stateChanged, this,
                         [this](QAbstractSocket::SocketState state) { handleStateChange(state, false); }))
     {}
 
-    explicit SocketReadySignalHelper(const QAbstractSocket *socket, void(QIODevice::*readySignal)(qint64))
+    explicit AbstractSocketReadySignalHelper(const QAbstractSocket *socket, void(QIODevice::*readySignal)(qint64))
         : WaitSignalHelper(socket, readySignal)
         , mStateChanged(connect(socket, &QAbstractSocket::stateChanged, this,
                         [this](QAbstractSocket::SocketState state) {
@@ -51,7 +51,7 @@ QCoro::Task<std::optional<bool>> QCoroAbstractSocket::waitForReadyReadImpl(std::
         co_return false;
     }
 
-    SocketReadySignalHelper helper(socket, &QIODevice::readyRead);
+    AbstractSocketReadySignalHelper helper(socket, &QIODevice::readyRead);
     co_return co_await qCoro(&helper, qOverload<bool>(&WaitSignalHelper::ready), timeout);
 }
 
@@ -61,7 +61,7 @@ QCoro::Task<std::optional<qint64>> QCoroAbstractSocket::waitForBytesWrittenImpl(
         co_return std::nullopt;
     }
 
-    SocketReadySignalHelper helper(socket, &QIODevice::bytesWritten);
+    AbstractSocketReadySignalHelper helper(socket, &QIODevice::bytesWritten);
     co_return co_await qCoro(&helper, qOverload<qint64>(&WaitSignalHelper::ready), timeout);
 }
 


### PR DESCRIPTION
There are two classes called SocketReadySignalHelper in two
anonymous namespaces in two distinct TUs. Since they are both
used as arguments to a coroutine, the compiler has generated for
each invocation of the coroutine a stackframe struct, which
contained SocketReadySignalHelper in its name. However, the frame
structs are not stored in an anonymous namespace, and due to the
classes both having the same name, we ended up with two distict
classes with the same name in two different TUs. Because they are
not in an anonymous namespace, the link time optimizer tries to
solve the duplication and runs into an ODR violation.

To workaround this, what I believe is a GCC bug, this change renames
the structures to each have a unique name.

The name of the generated frame struct was
_Z5qCoroIN12_GLOBAL__N_123SocketReadySignalHelperEMN5QCoro6detail16WaitSignalHelperEFvbEENS2_4TaskINS3_11QCoroSignalIT_T0_E11result_typeEEEPS9_OSA_NSt6chrono8durationIlSt5ratioILl1ELl1000EEEE.Frame

Edit: it is a known GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101118