### PR TITLE
CI: disable shared libs on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,13 +62,19 @@ jobs:
       shell: bash
       working-directory: ${{ github.workspace }}/build
       run: |
+        if [[ "${{ matrix.platform }}" != "windows" ]]; then
+          # Don't built QCoro as .dlls on Windows - making it work with ASAN on Github CI
+          # is major PITA...
+          EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DBUILD_SHARED_LIBS=ON"
+        fi
+
         QT_VERSION_MAJOR=$(echo ${{ matrix.qt_version }} | cut -d'.' -f1)
         cmake $GITHUB_WORKSPACE \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DUSE_QT_VERSION=$QT_VERSION_MAJOR \
-          -DBUILD_SHARED_LIBS=ON \
           -DQCORO_WITH_QTDBUS=${{ matrix.with_qtdbus }} \
-          -DQCORO_WITH_ASAN=ON
+          -DQCORO_WITH_ASAN=ON \
+          ${EXTRA_CMAKE_FLAGS}
 
     - name: Add ASAN DLL directory to PATH
       if: ${{ matrix.platform == 'windows' }}
@@ -114,7 +120,7 @@ jobs:
       with:
         name: build-${{ matrix.platform }}-${{ matrix.compiler_full }}-qt-${{ matrix.qt_version }}
         path: build/**
-  
+
   event_file:
     name: "Event File"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Debugging tests on CI is super-hard and I am unable to get it to
find all the DLLs on Windows, because it's all just a mess...