### PR TITLE
Explicitly enable exception support for clang-cl (fixes #90)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,12 @@ if (MSVC)
     # Disable warning C5054: "operator '&': deprecated between enumerations of different types" caused by QtWidgets/qsizepolicy.h
     # Disable warning C4127: "conditional expression is constant" caused by QtCore/qiterable.h
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd5054 /wd4127")
+
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        # Explicitly enable exceptions support for clang-cl (it's only enabled by CMake when targeting the Windows-MSVC platform,
+        # see https://github.com/danvratil/qcoro/issues/90 for details)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
+    endif()
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -pedantic")
 endif()


### PR DESCRIPTION
MSVC requires that exceptions are explicitly enabled using the `\EH`
flag, so clang-cl copies that behavior. When CMake targets the
Windows-MSVC platform (that is when using "Visual Studio" generator),
CMake takes care of adding `\EHsc` to `CXXFLAGS`. However when the
clang-cl compiler is specified manually (`CMAKE_CXX_COMPILER`) and
another generator, like Ninja is used, then CMake ends up targeting
the Windows-Clang-CXX platform, which does not enable exceptions,
so we have to do that ourselves. To keep the code simple, we do not
try to detect the target platform or such, we simply append the `\EHsc`
flag when we detect clang-cl.