### PR TITLE
Fix and clarify exception handling in generators

### DIFF
--- a/docs/reference/coro/generator.md
+++ b/docs/reference/coro/generator.md
@@ -118,3 +118,11 @@ it in `std::unique_ptr` or `QScopeGuard`.
     Keep in mind, that that generator coroutine will keep occupying
     memory even when not used until it finishes or until the
     associated `QCoro::Generator<T>` is destroyed.
+
+## Exceptions
+
+When a generator coroutine throws an exception, it will be rethrown
+from `operator++()` or from generator's `begin()` method.
+
+Afterwards the iterator is considered invalid and the generator
+is finished and may not be used anymore.

--- a/qcoro/qcoroasyncgenerator.h
+++ b/qcoro/qcoroasyncgenerator.h
@@ -207,10 +207,23 @@ public:
         : m_coroutine(coroutine)
     {}
 
+    /**
+     * @brief Asynchronously increments the iterator
+     *
+     * Resume the generator coroutine and asynchonously waits for it
+     * to yield a value. Resolves to a new iterator with the new value.
+     *
+     * If the generator coroutine throws an exception, co_awaiting on the
+     * returned awaitable will re-throw the exception and the returned iterator
+     * will be invalid (past-the-end iterator).
+     **/
     auto operator++() noexcept {
         return IncrementIteratorAwaitable{*this};
     }
 
+    /**
+     * Returns reference to the value yielded by the generator coroutine.
+     */
     reference operator *() const noexcept {
         return m_coroutine.promise().value();
     }
@@ -309,6 +322,8 @@ public:
      *
      * The asynchronout iterator can be used like a regular iterator, except that incrementing
      * the iterator returns an awaitable that must be co_awaited.
+     *
+     * If the generator coroutine throws an exception, it will be rethrown here.
      */
     auto begin() noexcept {
         class BeginIteratorAwaitable final : public detail::IteratorAwaitableBase {

--- a/tests/qcorogenerator.cpp
+++ b/tests/qcorogenerator.cpp
@@ -146,6 +146,37 @@ private Q_SLOTS:
         }
         QCOMPARE(testval, 4);
     }
+
+    void testException() {
+        const auto createGenerator = []() -> QCoro::Generator<int> {
+            for (int i = 0; i < 10; ++i) {
+                if (i == 2) {
+                    throw std::runtime_error("Two?! I can't handle two!!");
+                }
+                co_yield i;
+            }
+        };
+
+        auto generator = createGenerator();
+        auto it = generator.begin();
+        QVERIFY(it != generator.end());
+        QCOMPARE(*it, 0);
+        ++it;
+        QVERIFY(it != generator.end());
+        QCOMPARE(*it, 1);
+
+        QVERIFY_EXCEPTION_THROWN(++it, std::runtime_error);
+        QCOMPARE(it, generator.end());
+    }
+
+    void testExceptionInBegin() {
+        auto generator = []() -> QCoro::Generator<int> {
+            throw std::runtime_error("Zero is too small!");
+            co_yield 1;
+        }();
+
+        QVERIFY_EXCEPTION_THROWN(generator.begin(), std::runtime_error);
+    }
 };
 
 QTEST_GUILESS_MAIN(GeneratorTest)


### PR DESCRIPTION
Both sync and async generators now behave the same way. If the
generator coroutine throws an exception, it is rethrown either
from generator's begin() method, or when incrementing the
generator iterator.

Afterwards both the iterator and the generator are considered
invalid and may not be used anymore.