### PR TITLE
Fix QCoroFuture::waitForFinished triggerring twice on cancelation

### DIFF
--- a/qcoro/core/qcorofuture.h
+++ b/qcoro/core/qcorofuture.h
@@ -33,12 +33,10 @@ private:
 
         void await_suspend(std::coroutine_handle<> awaitingCoroutine) {
             auto *watcher = new QFutureWatcher<T_>();
-            auto cb = [watcher, awaitingCoroutine]() mutable {
+            QObject::connect(watcher, &QFutureWatcherBase::finished, [watcher, awaitingCoroutine]() mutable {
                 watcher->deleteLater();
                 awaitingCoroutine.resume();
-            };
-            QObject::connect(watcher, &QFutureWatcher<T_>::finished, cb);
-            QObject::connect(watcher, &QFutureWatcher<T_>::canceled, cb);
+            });
             watcher->setFuture(mFuture);
         }
 


### PR DESCRIPTION
While not explicitly documented, when a QFuture is canceled it will enter both cancelled and finished state (and emit both signals). Since we were listening to both signals, a canceled QFuture would cause QCoroFuture to resume the awaiter once on the canceled signal and then again when the finished() signal is emitted, possibly leading to a crash when the awaiter has already been destroyed after the first resume.

More details in discussion #108.