### PR TITLE
Make QCoro::connect more generic

### DIFF
--- a/docs/reference/coro/task.md
+++ b/docs/reference/coro/task.md
@@ -181,7 +181,7 @@ This is an example for a function that fetches data and updates a model:
 ```cpp
 void updateModel() {
     auto task = someCoroutine();
-    QCoro::connect(task, this, [this](auto &&result) {
+    QCoro::connect(std::move(task), this, [this](auto &&result) {
         beginResetModel();
         m_entries = std::move(result);
         endResetModel();


### PR DESCRIPTION
- Member function pointers are now allowed as callback
- Any awaitable can now be connected to.
- It's now possible to pass temporaries to connect, as they previously couldn't passed in by mutable reference