### PR TITLE
test: use offscreen QPA for QCoroQuick tests

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -75,7 +75,7 @@ jobs:
       shell: bash
       run: |
         cd build
-        QT_LOGGING_TO_CONSOLE=1 QT_QPA_PLATFORM=offscreen ctest -C $BUILD_TYPE \
+        QT_LOGGING_TO_CONSOLE=1 ctest -C $BUILD_TYPE \
           --output-on-failure \
           --verbose \
           --output-junit ${{ matrix.platform }}-${{ matrix.compiler_full }}-qt-${{ matrix.qt_version }}.xml

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,9 @@ function(qcoro_add_quick_test _name)
         Qt${QT_VERSION_MAJOR}::Quick
         Qt${QT_VERSION_MAJOR}::QuickPrivate
     )
+    get_test_property(test-${_name} ENVIRONMENT _env)
+    list(APPEND _env QT_QPA_PLATFORM=offscreen)
+    set_tests_properties(test-${_name} PROPERTIES ENVIRONMENT "${_env}")
 endfunction()
 
 qcoro_add_test(qtimer)


### PR DESCRIPTION
QCoroQuick requires QGuiApplication, but we usually don't have a running X session on the CI, which makes the test fail. By using the offscreen QPA, we make Qt happy without having to fiddle with Xvfb or something like that.

Fixes test failure reported in #139.