### PR TITLE
Make QCoro::Generator<T> properly move-constructible

### DIFF
--- a/qcoro/qcorogenerator.h
+++ b/qcoro/qcorogenerator.h
@@ -236,9 +236,16 @@ public:
     using iterator = GeneratorIterator<T>;
 
     explicit Generator() = default;
-    Generator(Generator &&) noexcept = default;
+    Generator(Generator &&other) noexcept {
+        mGeneratorCoroutine = other.mGeneratorCoroutine;
+        other.mGeneratorCoroutine = std::coroutine_handle<promise_type>::from_address(nullptr);
+    }
     Generator(const Generator &) = delete;
-    Generator &operator=(Generator &&) noexcept = default;
+    Generator &operator=(Generator &&other) noexcept {
+            mGeneratorCoroutine = other.mGeneratorCoroutine;
+            other.mGeneratorCoroutine = std::coroutine_handle<promise_type>::from_address(nullptr);
+            return *this;
+    };
     Generator &operator=(const Generator &) = delete;
     /**
      * @brief Destroys this Generator object and the associated generator coroutine.
@@ -246,7 +253,9 @@ public:
      * All values allocated on the generator stack are destroyed automatically.
      */
     ~Generator() {
-        mGeneratorCoroutine.destroy();
+        if (mGeneratorCoroutine.address() != nullptr) {
+            mGeneratorCoroutine.destroy();
+        }
     }
 
     /**

--- a/tests/qcoroasyncgenerator.cpp
+++ b/tests/qcoroasyncgenerator.cpp
@@ -168,6 +168,25 @@ private:
         QCORO_COMPARE(testvalue, 4);
     }
 
+    QCoro::Task<> testMovedGenerator_coro(QCoro::TestContext) {
+        const auto createGenerator = []() -> QCoro::AsyncGenerator<int> {
+            for (int i = 0; i < 4; ++i) {
+                co_await sleep(10ms);
+                co_yield i;
+            }
+        };
+
+        auto originalGenerator = createGenerator();
+        auto generator = std::move(originalGenerator);
+        int testvalue = 0;
+        for (auto it = co_await generator.begin(), end = generator.end(); it != end; co_await ++it) {
+            int value = *it;
+            QCORO_COMPARE(value, testvalue++);
+        }
+        QCORO_COMPARE(testvalue, 4);
+
+    }
+
     QCoro::Task<> testException_coro(QCoro::TestContext) {
         const auto createGenerator = []() -> QCoro::AsyncGenerator<int> {
             for (int i = 0; i < 4; ++i) {
@@ -243,6 +262,7 @@ private Q_SLOTS:
     addTest(ReferenceGenerator)
     addTest(ConstReferenceGenerator)
     addTest(MoveonlyGenerator)
+    addTest(MovedGenerator)
     addTest(Exception)
     addTest(ExceptionInDereference)
     addTest(ExceptionInBegin)

--- a/tests/qcorogenerator.cpp
+++ b/tests/qcorogenerator.cpp
@@ -147,6 +147,25 @@ private Q_SLOTS:
         QCOMPARE(testval, 4);
     }
 
+    void testMovedGenerator() {
+        const auto createGenerator = []() -> QCoro::Generator<int> {
+            for (int i = 0; i < 4; ++i) {
+                co_yield i;
+            }
+        };
+
+        auto originalGenerator = createGenerator();
+        auto generator = std::move(originalGenerator);
+        auto it = generator.begin();
+        int testval = 0;
+        while (it != generator.end()) {
+            int value = *it;
+            QCOMPARE(value, testval++);
+            ++it;
+        }
+        QCOMPARE(testval, 4);
+    }
+
     void testException() {
         const auto createGenerator = []() -> QCoro::Generator<int> {
             for (int i = 0; i < 10; ++i) {


### PR DESCRIPTION
`QCoro::Generator<T>` is currently not properly move-constructible, as the move constructor holds a reference to the existing `std::coroutine_handle`, destroying it when the original generator is destroyed.

This PR creates a custom move constructor for `QCoro::Generator<T>` in order to properly move-construct it.