### PR TITLE
iOS support: handle QProcess being not available

### DIFF
--- a/qcoro/core/qcoroprocess.cpp
+++ b/qcoro/core/qcoroprocess.cpp
@@ -2,6 +2,10 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <QtGlobal>
+
+#if QT_CONFIG(process)
+
 #include "qcoroprocess.h"
 #include "qcorosignal.h"
 
@@ -51,3 +55,5 @@ QCoro::Task<bool> QCoroProcess::start(const QString &program, const QStringList 
     static_cast<QProcess *>(mDevice.data())->start(program, arguments, mode);
     return waitForStarted(timeout);
 }
+
+#endif // QT_CONFIG(process)

--- a/qcoro/core/qcoroprocess.h
+++ b/qcoro/core/qcoroprocess.h
@@ -12,6 +12,8 @@
 
 #include <QIODevice>
 
+#if QT_CONFIG(process)
+
 class QProcess;
 
 namespace QCoro::detail {
@@ -126,3 +128,4 @@ inline auto qCoro(QProcess *p) noexcept {
     return QCoro::detail::QCoroProcess{p};
 }
 
+#endif // QT_CONFIG(process)


### PR DESCRIPTION
Handle QProcess missing on iOS in the same way Qt itself does: put all the QProcess related code inside a
 #if QT_CONFIG(process)
