### PR TITLE
Fix CheckAtomic failing on Windows with Clang

### DIFF
--- a/cmake/CheckAtomic.cmake
+++ b/cmake/CheckAtomic.cmake
@@ -8,7 +8,7 @@ INCLUDE(CheckLibraryExists)
 
 function(check_working_cxx_atomics varname)
   set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++20")
   CHECK_CXX_SOURCE_COMPILES("
 #include <atomic>
 std::atomic<int> x;


### PR DESCRIPTION
Looks one of the MSVC standard headers uses C++14 syntax, but we were building the test in C++11 mode which failed the build. This change compiles the test with C++20 so we should be safe on all sides.