### PR TITLE
QML: Add declarative API for awaiting a task

### DIFF
--- a/docs/reference/qml/qmltask.md
+++ b/docs/reference/qml/qmltask.md
@@ -37,10 +37,25 @@ public:
 }
 ```
 
+QmlTasks can call a JavaScript function when they complete:
 ```QML
 Example {
     Component.onCompleted: {
         fetchValue("key").then((result) => console.log("Result", result))
+    }
+}
+```
+
+They can also set properties when the value is available:
+```QML
+import QCoro 0
+import io.me.qmlmodule 1.0
+
+Item {
+    Example { id: store }
+
+    Label {
+        text: store.fetchValue("key").await().value
     }
 }
 ```

--- a/qcoro/qml/qcoroqml.cpp
+++ b/qcoro/qml/qcoroqml.cpp
@@ -10,4 +10,5 @@
 
 void QCoro::Qml::registerTypes() {
     qRegisterMetaType<QCoro::QmlTask>();
+    qmlRegisterAnonymousType<QCoro::QmlTaskListener>("QCoro", 0);
 }

--- a/qcoro/qml/qcoroqmltask.cpp
+++ b/qcoro/qml/qcoroqmltask.cpp
@@ -73,4 +73,26 @@ void QmlTask::then(QJSValue func) {
     });
 }
 
+QmlTaskListener *QmlTask::await()
+{
+    QPointer listener = new QmlTaskListener();
+    d->task->then([listener](auto &&value) {
+        if (listener) {
+            listener->setValue(std::move(value));
+        }
+    });
+    return listener;
+}
+
+QVariant QmlTaskListener::value() const
+{
+    return m_value;
+}
+
+void QmlTaskListener::setValue(QVariant &&value)
+{
+    m_value = std::move(value);
+    Q_EMIT valueChanged();
+}
+
 }

--- a/qcoro/qml/qcoroqmltask.cpp
+++ b/qcoro/qml/qcoroqmltask.cpp
@@ -73,9 +73,12 @@ void QmlTask::then(QJSValue func) {
     });
 }
 
-QmlTaskListener *QmlTask::await()
+QmlTaskListener *QmlTask::await(const QVariant &intermediateValue)
 {
     QPointer listener = new QmlTaskListener();
+    if (!intermediateValue.isNull()) {
+        listener->setValue(QVariant(intermediateValue));
+    }
     d->task->then([listener](auto &&value) {
         if (listener) {
             listener->setValue(std::move(value));

--- a/qcoro/qml/qcoroqmltask.h
+++ b/qcoro/qml/qcoroqmltask.h
@@ -86,8 +86,11 @@ public:
      * ```
      * text: asyncLoadText().await().value
      * ```
+     *
+     * Optionally, an intermediate value can be passed to await,
+     * which will be returned by value while calculating the asynchronous result.
      */
-    Q_INVOKABLE QCoro::QmlTaskListener *await();
+    Q_INVOKABLE QCoro::QmlTaskListener *await(const QVariant &intermediateValue = {});
 
 private:
     QSharedDataPointer<QmlTaskPrivate> d;

--- a/qcoro/qml/qcoroqmltask.h
+++ b/qcoro/qml/qcoroqmltask.h
@@ -17,6 +17,8 @@ namespace QCoro {
 
 struct QmlTaskPrivate;
 
+class QmlTaskListener;
+
 //! QML type that allows to react to asynchronous computations from QML
 struct QCOROQML_EXPORT QmlTask {
     Q_GADGET
@@ -77,8 +79,31 @@ public:
      */
     Q_INVOKABLE void then(QJSValue func);
 
+    //! Allows to use tasks in property bindings
+    /*!
+     * The value property is initially null, and will be updated to the actual value once it is available.
+     * Example usage:
+     * ```
+     * text: asyncLoadText().await().value
+     * ```
+     */
+    Q_INVOKABLE QCoro::QmlTaskListener *await();
+
 private:
     QSharedDataPointer<QmlTaskPrivate> d;
+};
+
+class QmlTaskListener : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QVariant value READ value NOTIFY valueChanged)
+
+public:
+    QVariant value() const;
+    void setValue(QVariant &&value);
+    Q_SIGNAL void valueChanged();
+
+private:
+    QVariant m_value;
 };
 
 }

--- a/tests/qcoroqmltask.cpp
+++ b/tests/qcoroqmltask.cpp
@@ -47,7 +47,7 @@ public:
     Q_INVOKABLE void reportTestSuccess() {
         numTestsPassed++;
 
-        if (numTestsPassed == 3) { // Number of java script functions that call reportTestSuccess
+        if (numTestsPassed == 4) { // Number of java script functions that call reportTestSuccess
             Q_EMIT success();
         }
     }
@@ -72,9 +72,18 @@ private:
 
         engine.loadData(R"(
 import qcoro.test 0.1
+import QCoro 0
 import QtQuick 2.7
 
 QtObject {
+    property string value: QmlObject.qmlTaskFromFuture().await().value
+    onValueChanged: {
+        if (value == "Success") {
+            console.log("awaiting finished")
+            QmlObject.reportTestSuccess()
+        }
+    }
+
     Component.onCompleted: {
         QmlObject.startTimer().then(() => {
             console.log("QCoro::Task JavaScript callback called")
@@ -106,6 +115,7 @@ QtObject {
             timeout->stop();
             running = false;
         });
+
         // Crash the test in case the timeout was reachaed without the callback being called
         connect(timeout, &QTimer::timeout, this, [&]() {
 #if defined(Q_CC_CLANG) && defined(Q_OS_WINDOWS)

--- a/tests/qcoroqmltask.cpp
+++ b/tests/qcoroqmltask.cpp
@@ -76,7 +76,10 @@ import QCoro 0
 import QtQuick 2.7
 
 QtObject {
-    property string value: QmlObject.qmlTaskFromFuture().await().value
+    property string value: QmlObject.qmlTaskFromFuture().await("Loading...").value
+
+    property string valueWithoutIntermediate: QmlObject.qmlTaskFromFuture().await().value
+
     onValueChanged: {
         if (value == "Success") {
             console.log("awaiting finished")


### PR DESCRIPTION
This is a proposal for a bit nicer API for awaiting. In exchange for being a bit heavier, it allows declarative usage.