### PR TITLE
qcorowebsocket replace QWebSocket::error with QWebSocket::errorOccurred

### DIFF
--- a/qcoro/websockets/qcorowebsocket.cpp
+++ b/qcoro/websockets/qcorowebsocket.cpp
@@ -32,7 +32,13 @@ public:
                 emitReady(true);
             }
         }))
-        , mError(connect(socket, qOverload<QAbstractSocket::SocketError>(&QWebSocket::error), this, [this](auto error) {
+        , mError(connect(socket, qOverload<QAbstractSocket::SocketError>(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+                                     &QWebSocket::errorOccurred
+#else
+                                     &QWebSocket::error
+#endif
+                                     ), this, [this](auto error) {
             qWarning() << "QWebSocket failed to connect to a websocket server: " << error;
             emitReady(false);
         }))


### PR DESCRIPTION
I build using cmake build configuration "Debug" not "RelWithDebInfo".
Building qcoro fails with error "qcoro/qcoro/websockets/qcorowebsocket.cpp: 35:73: error: ‘void QWebSocket::error(QAbstractSocket::SocketError)’ is deprecated: Use errorOccurred instead [-Werror=deprecated-declarations]".
Because "# Only enable strict warnings in debug mode
set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Werror -pedantic")".