### PR TITLE
QCoro::connect: Fix bug in concept requirements

### DIFF
--- a/qcoro/qcorotask.h
+++ b/qcoro/qcorotask.h
@@ -833,7 +833,7 @@ void connect(QCoro::Task<T> &&task, QObjectSubclass *context, Callback func) {
 
 template <typename T, typename QObjectSubclass, typename Callback>
 requires detail::TaskConvertible<T>
-        && (std::is_invocable_v<Callback> || std::is_invocable_v<Callback, detail::convertible_awaitable_return_type_t<T>> || std::is_invocable_v<Callback, QObjectSubclass *> || std::is_invocable_v<Callback, QObjectSubclass *, T>)
+        && (std::is_invocable_v<Callback> || std::is_invocable_v<Callback, detail::convertible_awaitable_return_type_t<T>> || std::is_invocable_v<Callback, QObjectSubclass *> || std::is_invocable_v<Callback, QObjectSubclass *, detail::convertible_awaitable_return_type_t<T>>)
         && (!detail::isTask_v<T>)
 void connect(T &&future, QObjectSubclass *context, Callback func) {
     auto task = detail::toTask(std::move(future));


### PR DESCRIPTION
We are currently testing whether the lambda is invokable with the task
as argument, which it should not be.

Weirdly enough this actually works with modern versions of clang and
gcc, but I'm pretty sure its still wrong.
