### PR TITLE
QCoroSignalListener: support connecting to private signals

### DIFF
--- a/tests/qcorosignal.cpp
+++ b/tests/qcorosignal.cpp
@@ -229,7 +229,7 @@ private:
 
         const auto result = co_await qCoro(&obj, &SignalTest::privateVoid);
         static_assert(std::is_same_v<decltype(result), const std::tuple<>>);
-
+        Q_UNUSED(result);
     }
 
     QCoro::Task<> testSingleArgQPrivateSignal_coro(QCoro::TestContext) {
@@ -243,7 +243,7 @@ private:
     QCoro::Task<> testMultiArgQPrivateSignal_coro(QCoro::TestContext) {
         SignalTest obj;
 
-        const auto [str, num, ptr ] = co_await qCoro(&obj, &SignalTest::privateMultiArg);
+        const auto [str, num, ptr] = co_await qCoro(&obj, &SignalTest::privateMultiArg);
         static_assert(std::is_same_v<decltype(str), const QString>);
         static_assert(std::is_same_v<decltype(num), const int>);
         static_assert(std::is_same_v<decltype(ptr), QObject * const>);
@@ -344,6 +344,56 @@ private:
         QCORO_COMPARE(co_await msg2, 2);
     }
 
+    QCoro::Task<> testSignalListenerQPrivateSignalVoid_coro(QCoro::TestContext) {
+        MultiSignalTest obj;
+
+        auto generator = qCoroSignalListener(&obj, &MultiSignalTest::privateVoid);
+        int count = 0;
+        QCORO_FOREACH(const auto &value, generator) {
+            static_assert(std::is_same_v<decltype(value), const std::tuple<> &>);
+            Q_UNUSED(value);
+            if (++count == 10) {
+                break;
+            }
+        }
+
+        QCORO_COMPARE(count, 10);
+    }
+
+    QCoro::Task<> testSignalListenerQPrivateSignalValue_coro(QCoro::TestContext) {
+         MultiSignalTest obj;
+
+        auto generator = qCoroSignalListener(&obj, &MultiSignalTest::privateSingleArg);
+        int count = 0;
+        QCORO_FOREACH(const auto &value, generator) {
+            static_assert(std::is_same_v<decltype(value), const QString &>);
+            QCORO_COMPARE(value, QStringLiteral("YAY!"));
+            if (++count == 10) {
+                break;
+            }
+        }
+
+        QCORO_COMPARE(count, 10);
+    }
+
+    QCoro::Task<> testSignalListenerQPrivateSignalTuple_coro(QCoro::TestContext) {
+        MultiSignalTest obj;
+
+        auto generator = qCoroSignalListener(&obj, &MultiSignalTest::privateMultiArg);
+        int count = 0;
+        QCORO_FOREACH(const auto &value, generator) {
+            static_assert(std::is_same_v<decltype(value), const std::tuple<QString, int, QObject *> &>);
+            QCORO_COMPARE(std::get<QString>(value), QStringLiteral("YAY!"));
+            QCORO_COMPARE(std::get<int>(value), 42);
+            QCORO_COMPARE(std::get<QObject *>(value), &obj);
+            if (++count == 10) {
+                break;
+            }
+        }
+
+        QCORO_COMPARE(count, 10);
+    }
+
 private Q_SLOTS:
     addTest(Triggers)
     addTest(ReturnsValue)
@@ -367,6 +417,9 @@ private Q_SLOTS:
     addTest(SignalListenerTimeout)
     addTest(SignalListenerQueue)
     addTest(SignalAfterListenerQuits)
+    addTest(SignalListenerQPrivateSignalVoid)
+    addTest(SignalListenerQPrivateSignalValue)
+    addTest(SignalListenerQPrivateSignalTuple)
 };
 
 QTEST_GUILESS_MAIN(QCoroSignalTest)


### PR DESCRIPTION
The slot parameter extraction code is moved to common base class of QCoroSignal and QCoroSignalListener so that the logic and fixes are shared in the future. As an intended side-effect, QCoroSignalListener gains support for connecting to signals wit QPrivateSignal (the so called private signals).