### PR TITLE
fix error: std::coroutine_traits isn't a class template

### DIFF
--- a/qcoro/coroutine.h
+++ b/qcoro/coroutine.h
@@ -92,10 +92,11 @@ struct coroutine_handle : public std::coroutine_handle<Promise> {};
 
 } // namespace experimental
 
+#if defined(__cpp_lib_coroutine)
 // Import std::experimental::coroutine_traits into the std namespace
 template<typename R, typename ... ArgTypes>
 using coroutine_traits = std::experimental::coroutine_traits<R, ArgTypes ...>;
-
+#endif
 
 // 17.12.3, coroutine handle
 


### PR DESCRIPTION
Simple fix to prevent a build error with LLVM16:
```
FAILED: examples/basics/CMakeFiles/await-sync-string.dir/await-sync-string.cpp.o 
/usr/ports/pobj/qcoro-0.9.0/bin/c++ -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_FROM_BYTEARRAY -DQT_NO_CAST_TO_ASCII -DQT_NO_FOREACH -DQT_NO_KEYWORDS -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT -DQT_NO_URL_CAST_FROM_STRING -DQT_STRICT_ITERATORS -DQT_USE_STRINGBUILDER -I/usr/ports/pobj/qcoro-0.9.0/build-amd64/examples/basics/await-sync-string_autogen/include -I/usr/ports/pobj/qcoro-0.9.0/qcoro-0.9.0 -I/usr/ports/pobj/qcoro-0.9.0/qcoro-0.9.0/qcoro -I/usr/ports/pobj/qcoro-0.9.0/build-amd64/qcoro -O2 -pipe -DNDEBUG -std=gnu++20 -MD -MT examples/basics/CMakeFiles/await-sync-string.dir/await-sync-string.cpp.o -MF examples/basics/CMakeFiles/await-sync-string.dir/await-sync-string.cpp.o.d -o examples/basics/CMakeFiles/await-sync-string.dir/await-sync-string.cpp.o -c /usr/ports/pobj/qcoro-0.9.0/qcoro-0.9.0/examples/basics/await-sync-string.cpp
In file included from /usr/ports/pobj/qcoro-0.9.0/qcoro-0.9.0/examples/basics/await-sync-string.cpp:5:
/usr/ports/pobj/qcoro-0.9.0/qcoro-0.9.0/qcoro/coroutine.h:97:1: error: std::coroutine_traits isn't a class template
using coroutine_traits = std::experimental::coroutine_traits<R, ArgTypes ...>;
^

```

$ clang++ --version
OpenBSD clang version 16.0.6
Target: amd64-unknown-openbsd7.4
Thread model: posix
InstalledDir: /usr/bin