### PR TITLE
Suppress Clang error when building against Android NDK <= 25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,17 @@ if (MSVC)
 else()
     # Only enable strict warnings in debug mode
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -Werror -pedantic")
+
+    if (ANDROID)
+        include(DetectAndroidNDKVersion)
+        detectAndroidNDKVersion(NDK_VERSION)
+        if ("${NDK_VERSION}" VERSION_LESS 26)
+            # Android NDK < 26 ships mismatching versions of clang and libc++ - libc++ is older and doesn't have coroutine support
+            # which forces us to use coroutines from std::experimental. But the clang itself is newer and emits an error about
+            # std::experimental coroutines being deprecated in LLVM 14. This option is needed to suppress the error.
+            add_compile_options(-Wno-error=deprecated-experimental-coroutine)
+        endif()
+    endif()
 endif()
 
 if (QCORO_ENABLE_ASAN)

--- a/cmake/DetectAndroidNDKVersion.cmake
+++ b/cmake/DetectAndroidNDKVersion.cmake
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2023 Daniel Vrátil <dvratil@kde.org>
+#
+# SPDX-License-Identifier: MIT
+
+cmake_policy(SET CMP0140 NEW)
+
+function(detectAndroidNDKVersion outVar)
+    if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
+        # CMAKE_ANDROID_NDK_VERSION introduced in CMake 3.20
+        set(${outVar} "${CMAKE_ANDROID_NDK_VERSION}")
+    else()
+        if (NOT CMAKE_ANDROID_NDK)
+            message(STATUS "Couldn't detect Android NDK version: CMAKE_ANDROID_NDK not set")
+            return()
+        endif()
+        if (NOT EXISTS "${CMAKE_ANDROID_NDK}/source.properties")
+            message(STATUS "Couldn't detect Android NDK version: ${CMAKE_ANDROID_NDK}/source.properties doesn't exist")
+            return()
+        endif()
+        file(STRINGS "${CMAKE_ANDROID_NDK}/source.properties" _sources REGEX "^Pkg\.Revision = [0-9]+\.[0-9]+\.[0-9]+$")
+        string(REGEX MATCH "= ([0-9]+\.[0-9]+)\." _match "${_sources}")
+        set(${outVar} "${CMAKE_MATCH_1}")
+        if (NOT ${outVar})
+            message(STATUS "Couldn't detect Android NDK version: ${CMAKE_ANDROID_NDK}/source.properties doesn't contain Pkg.Revision")
+            return()
+        endif()
+
+    endif()
+
+    message(STATUS "Detected Android NDK version ${${outVar}}")
+    return(PROPAGATE ${outVar})
+endfunction()


### PR DESCRIPTION
Android NDK <= 25 ships mismatching version of clang and libc++. The libc++ in the NDK is old and doesn't support coroutines, which forces us to fallback to using coroutines from std::experimental namespace. However, the clang version is newer and causes a compile error when using coroutines from std::experimental, because as of LLVM 14, coroutines are fully implemented.

To suppresss the error, we must set a special compile option. This is fixed with NDK 26, which now ships libc++ from LLVM toolchain, so the version matches the compiler version (and they updated to LLVM 17 with full coroutine support).

Resolves issue #204.