### PR TITLE
Fix coroutine being resumed on a wrong thread after timeout

### DIFF
--- a/qcoro/core/qcorosignal.h
+++ b/qcoro/core/qcorosignal.h
@@ -114,7 +114,7 @@ public:
                 [this, awaitingCoroutine]() {
                     QObject::disconnect(mConn);
                     awaitingCoroutine.resume();
-                });
+                }, Qt::DirectConnection); // force coro to be resumed on our thread, not mObj's thread
             mTimeoutTimer->start();
         }
     }

--- a/tests/qcorosignal.cpp
+++ b/tests/qcorosignal.cpp
@@ -36,6 +36,8 @@ Q_SIGNALS:
     void privateVoid(QPrivateSignal);
     void privateSingleArg(const QString &, QPrivateSignal);
     void privateMultiArg(const QString &, int, QObject *, QPrivateSignal);
+
+    void signalThatsNeverEmitted();
 };
 
 class MultiSignalTest : public SignalTest {
@@ -394,6 +396,24 @@ private:
         QCORO_COMPARE(count, 10);
     }
 
+    QCoro::Task<> testSignalEmitterOnDifferentThread_coro(QCoro::TestContext) {
+        SignalTest test;
+        QThread thread;
+        test.moveToThread(&thread);
+        thread.start();
+
+        co_await qCoro(&test, &SignalTest::voidSignal);
+        // Make sure we are resumed on our thread
+        QCORO_COMPARE(QThread::currentThread(), qApp->thread());
+
+        co_await qCoro(&test, &SignalTest::signalThatsNeverEmitted, 20ms);
+        // Make sure we are resumed on our thread after the timeout
+        QCORO_COMPARE(QThread::currentThread(), qApp->thread());
+
+        thread.quit();
+        thread.wait();
+    }
+
 private Q_SLOTS:
     addTest(Triggers)
     addTest(ReturnsValue)
@@ -420,6 +440,7 @@ private Q_SLOTS:
     addTest(SignalListenerQPrivateSignalVoid)
     addTest(SignalListenerQPrivateSignalValue)
     addTest(SignalListenerQPrivateSignalTuple)
+    addTest(SignalEmitterOnDifferentThread)
 };
 
 QTEST_GUILESS_MAIN(QCoroSignalTest)

--- a/tests/qcorosignal.cpp
+++ b/tests/qcorosignal.cpp
@@ -8,6 +8,7 @@
 #include "qcoro/core/qcorosignal.h"
 
 #include <QTimer>
+#include <QThread>
 
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
When awaiting a signal emission with qCoro() would time out, we would resume the awaiting coroutine in the context of the thread in which the emitter lives instead of the thread in which qCoro() was called from.

Fixes #213