### PR TITLE
#include <exception>, needed by std::exception_ptr

### DIFF
--- a/qcoro/qcorotask.h
+++ b/qcoro/qcorotask.h
@@ -8,6 +8,7 @@
 #include "concepts_p.h"
 
 #include <atomic>
+#include <exception>
 #include <variant>
 #include <memory>
 #include <type_traits>


### PR DESCRIPTION
clang 18 build fails with "No member named 'exception_ptr' in namespace 'std'"