### PR TITLE
Prevent coroutine from being stuck if sender is deleted

### DIFF
--- a/docs/reference/core/signals.md
+++ b/docs/reference/core/signals.md
@@ -19,7 +19,9 @@ Task<SignalResult> qCoro(QObject *obj, QtSignalPtr ptr);
 
 The arguments are a pointer to a QObject-derived object and a pointer
 to a the object's signal to connect to. Note that if the object is destroyed
-while being `co_await`ed, the coroutine will never be resumed.
+while being `co_await`ed, the coroutine will never be resumed. If you want the
+couroutine to resume instead, use qCoroWatch()
+// ******************** Include example below **************** //
 
 The returned awaitable produces the signal's arguments. That is, if the
 signal has no arguments, the result of the awaitable will be `void`. If

--- a/docs/reference/core/signals.md
+++ b/docs/reference/core/signals.md
@@ -18,10 +18,7 @@ Task<SignalResult> qCoro(QObject *obj, QtSignalPtr ptr);
 ```
 
 The arguments are a pointer to a QObject-derived object and a pointer
-to a the object's signal to connect to. Note that if the object is destroyed
-while being `co_await`ed, the coroutine will never be resumed. If you want the
-couroutine to resume instead, use qCoroWatch()
-// ******************** Include example below **************** //
+to a the object's signal to connect to.
 
 The returned awaitable produces the signal's arguments. That is, if the
 signal has no arguments, the result of the awaitable will be `void`. If
@@ -41,6 +38,8 @@ const QUrl url = co_await qCoro(reply, &QNetworkReply::redirected);
 const auto [exitCode, exitStatus] = co_await qCoro(process, &QProcess::finished);
 ```
 
+## With a timeout
+
 ```cpp
 Task<std::optional<SignalResult>> qCoro(QObject *obj, QtSignalPtr ptr, std::chrono::milliseconds timeout);
 ```
@@ -49,6 +48,17 @@ An overload that behaves similar to the two-argument overload, but takes an addi
 `timeout` argument. If the signal is not emitted within the specified timeout,  the returned
 awaitable produces an empty `std::optional`. Otherwise the return type behaves the same way
 as the two-argument overload.
+
+## Sender lifetime
+In the examples above, the coroutine will never be resumed if the object is
+destroyed while being `co_await`ed. This can be problematic in some cases (for
+example if you have local variables that need to be freed). If you want the
+coroutine to resume instead, use `qCoroWatch()` instead of `qCoro()`. It also
+allows you to specify a timeout as an optional parameter.
+
+If the sender is deleted, or the signal is not emitted within the specified
+timeout, the returned awaitable produces an empty `std::optional`. Otherwise
+the return type behaves the same way as the two-argument overload.
 
 ## QCoroSignalListener
 

--- a/qcoro/core/qcorosignal.h
+++ b/qcoro/core/qcorosignal.h
@@ -171,7 +171,7 @@ public:
     QCoroSignal(T *obj, FuncPtr &&ptr, std::chrono::milliseconds timeout)
         : QCoroSignalBase<T, FuncPtr>(obj, std::forward<FuncPtr>(ptr), timeout)
         , mDummyReceiver(std::make_unique<QObject>()) {}
-    QCoroSignal(T *obj, FuncPtr &&ptr, T *context, std::chrono::milliseconds timeout)
+    QCoroSignal(T *obj, FuncPtr &&ptr, QObject *context, std::chrono::milliseconds timeout)
         : QCoroSignalBase<T, FuncPtr>(obj, std::forward<FuncPtr>(ptr), timeout),
           mContextObj(context),
           mDummyReceiver(std::make_unique<QObject>()) {}
@@ -260,7 +260,7 @@ private:
 
     result_type mResult;
 
-    QPointer<T> mContextObj;
+    QPointer<QObject> mContextObj;
     QMetaObject::Connection mContextConn;
     std::coroutine_handle<> mAwaitingCoroutine;
     std::unique_ptr<QObject> mDummyReceiver;
@@ -400,11 +400,11 @@ inline auto qCoro(T *obj, FuncPtr &&ptr, std::chrono::milliseconds timeout)
  * the operation will never time out.
  */
 template<QCoro::detail::concepts::QObject T, typename FuncPtr>
-inline auto qCoroWatch(T *obj, FuncPtr &&ptr,
-                       std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
+inline auto qCoro(T *obj, FuncPtr &&ptr, QObject *context,
+                  std::chrono::milliseconds timeout = std::chrono::milliseconds(-1))
     -> QCoro::Task<typename QCoro::detail::QCoroSignal<T, FuncPtr>::result_type> {
     auto result =
-        co_await QCoro::detail::QCoroSignal(obj, std::forward<FuncPtr>(ptr), obj, timeout);
+        co_await QCoro::detail::QCoroSignal(obj, std::forward<FuncPtr>(ptr), context, timeout);
     co_return std::move(result);
 }
 

--- a/tests/qcorosignal.cpp
+++ b/tests/qcorosignal.cpp
@@ -415,6 +415,16 @@ private:
         thread.wait();
     }
 
+    QCoro::Task<> testCoroutineResumeOnSenderDelete_coro(QCoro::TestContext) {
+        auto obj = new SignalTest;
+
+        QTimer::singleShot(10ms, obj, &QObject::deleteLater);
+
+        const auto result = co_await qCoroWatch(obj, &SignalTest::singleArg, 50ms);
+        static_assert(std::is_same_v<decltype(result), const std::optional<QString>>);
+        QCORO_VERIFY(!result.has_value());
+    }
+
 private Q_SLOTS:
     addTest(Triggers)
     addTest(ReturnsValue)
@@ -442,6 +452,7 @@ private Q_SLOTS:
     addTest(SignalListenerQPrivateSignalValue)
     addTest(SignalListenerQPrivateSignalTuple)
     addTest(SignalEmitterOnDifferentThread)
+    addTest(CoroutineResumeOnSenderDelete)
 };
 
 QTEST_GUILESS_MAIN(QCoroSignalTest)

--- a/tests/qcorosignal.cpp
+++ b/tests/qcorosignal.cpp
@@ -420,7 +420,7 @@ private:
 
         QTimer::singleShot(10ms, obj, &QObject::deleteLater);
 
-        const auto result = co_await qCoroWatch(obj, &SignalTest::singleArg, 50ms);
+        const auto result = co_await qCoroWatch(obj, &SignalTest::singleArg);
         static_assert(std::is_same_v<decltype(result), const std::optional<QString>>);
         QCORO_VERIFY(!result.has_value());
     }

--- a/tests/qcorosignal.cpp
+++ b/tests/qcorosignal.cpp
@@ -420,7 +420,7 @@ private:
 
         QTimer::singleShot(10ms, obj, &QObject::deleteLater);
 
-        const auto result = co_await qCoroWatch(obj, &SignalTest::singleArg);
+        const auto result = co_await qCoro(obj, &SignalTest::singleArg, obj);
         static_assert(std::is_same_v<decltype(result), const std::optional<QString>>);
         QCORO_VERIFY(!result.has_value());
     }


### PR DESCRIPTION
DRAFT: I'm only starting to use coroutines in a real project, so treat this as a PoC. I'd first like to know if this approach is acceptable. I also saw the `guardThis` implementation (#191)  but that seems to solving a different problem. If yes, I'll clean this up so to share some of the `QCoroSignal` code.

It is possible for a sender QObject to be deleted before it gets a chance to emit a signal that we are `co_await`'ing on. In such a case, the coroutine will never be resumed. A side-effect of this is that all variables that are local to that coroutine will never get deallocated and will stay in limbo forever.

For example, the following snippet:

```
    SomeObject obj;

    m_msgBox = new QMessageBox(this);
    m_msgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
    m_msgBox->setModal(false);
    m_msgBox->show();
    auto res = co_await qCoro(ad, &AnotherDialog::finished);

    // Do something with obj
```

The object `obj` will never get freed if `this` is deleted by something else (in a real life case, this can happen due to some conditions which require us to reload the current "project" in our app).

Using the new function `qCoroWatch` instead of `qCoro` let you do this:
```
    SomeObject obj;

    m_msgBox = new QMessageBox(this);
    m_msgBox->setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
    m_msgBox->setModal(false);
    m_msgBox->show();
    auto res = co_await qCoroWatch(ad, &AnotherDialog::finished);
    if (!res.has_value())    // Sender deleted
        co_return;

    // Do something with obj
```

As I said above, I'm only starting to use coroutines so it is possible that this has some limitations that I'm unaware of. I'm open to trying other approaches to solve the problem.