### PR TITLE
waitFor(QCoro::Task<T>): Do not require T to be default constructible

### DIFF
--- a/qcoro/impl/waitfor.h
+++ b/qcoro/impl/waitfor.h
@@ -83,7 +83,7 @@ T waitFor(Awaitable &&awaitable) {
         if (context.exception) {
             std::rethrow_exception(context.exception);
         }
-        return *result;
+        return std::move(*result);
     }
 }
 

--- a/qcoro/impl/waitfor.h
+++ b/qcoro/impl/waitfor.h
@@ -53,18 +53,7 @@ Task<> runCoroutine(WaitContext &context, Awaitable &&awaitable) {
 }
 
 template<typename T, Awaitable Awaitable>
-Task<> runCoroutine(WaitContext &context, T &result, Awaitable &&awaitable) {
-    try {
-        result = co_await awaitable;
-    } catch (...) {
-        context.exception = std::current_exception();
-    }
-    context.coroutineFinished = true;
-    context.loop.quit();
-}
-
-template<typename T, Awaitable Awaitable>
-Task<> runCoroutineOpt(WaitContext &context, std::optional<T> &result, Awaitable &&awaitable) {
+Task<> runCoroutine(WaitContext &context, std::optional<T> &result, Awaitable &&awaitable) {
     try {
         result.emplace(co_await awaitable);
     } catch (...) {
@@ -86,27 +75,15 @@ T waitFor(Awaitable &&awaitable) {
             std::rethrow_exception(context.exception);
         }
     } else {
-        if constexpr (std::is_default_constructible_v<T>) {
-            T result;
-            runCoroutine(context, result, std::forward<Awaitable>(awaitable));
-            if (!context.coroutineFinished) {
-                context.loop.exec();
-            }
-            if (context.exception) {
-                std::rethrow_exception(context.exception);
-            }
-            return result;
-        } else {
-            std::optional<T> result;
-            runCoroutineOpt(context, result, std::forward<Awaitable>(awaitable));
-            if (!context.coroutineFinished) {
-                context.loop.exec();
-            }
-            if (context.exception) {
-                std::rethrow_exception(context.exception);
-            }
-            return *result;
+        std::optional<T> result;
+        runCoroutine(context, result, std::forward<Awaitable>(awaitable));
+        if (!context.coroutineFinished) {
+            context.loop.exec();
         }
+        if (context.exception) {
+            std::rethrow_exception(context.exception);
+        }
+        return *result;
     }
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,7 @@ qcoro_add_test(testconstraints)
 qcoro_add_test(qfuture LINK_LIBRARIES Qt${QT_VERSION_MAJOR}::Concurrent)
 qcoro_add_test(qcorogenerator)
 qcoro_add_test(qcoroasyncgenerator)
+qcoro_add_test(qcorowaitfor)
 
 if (QCORO_WITH_QTDBUS)
     qcoro_add_dbus_test(qdbuspendingcall)

--- a/tests/qcorowaitfor.cpp
+++ b/tests/qcorowaitfor.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2024 Joey Richey <joey@dogsplayingpoker.org>
+//
+// SPDX-License-Identifier: MIT
+
+#include "testobject.h"
+
+#include "qcorotimer.h"
+
+#include <chrono>
+
+class QCoroWaitForTest : public QCoro::TestObject<QCoroWaitForTest> {
+    Q_OBJECT
+
+private:
+    QCoro::Task<void> testPrimitiveType_coro(QCoro::TestContext ctx)
+    {
+        ctx.setShouldNotSuspend();
+        auto task_test = []() -> QCoro::Task<int> {
+            co_return 7;
+        };
+
+        const int ret = QCoro::waitFor(task_test());
+        QCORO_VERIFY(ret == 7);
+    }
+
+    QCoro::Task<void> testDefaultConstructible_coro(QCoro::TestContext ctx)
+    {
+        ctx.setShouldNotSuspend();
+        auto task_test = []() -> QCoro::Task<std::string> {
+            co_return "seven";
+        };
+
+        const std::string ret = QCoro::waitFor(task_test());
+        QCORO_VERIFY(ret == "seven");
+    }
+
+    QCoro::Task<void> testNonDefaultConstructible_coro(QCoro::TestContext ctx)
+    {
+        ctx.setShouldNotSuspend();
+
+        struct test_struct {
+            explicit test_struct(int i_) : i(i_) {}
+            int i;
+        };
+
+        auto task_test = []() -> QCoro::Task<test_struct> {
+            co_return test_struct(7);
+        };
+
+        const test_struct ret = QCoro::waitFor(task_test());
+        QCORO_VERIFY(ret.i == 7);
+    }
+
+private Q_SLOTS:
+    addTest(PrimitiveType)
+    addTest(DefaultConstructible)
+    addTest(NonDefaultConstructible)
+};
+
+QTEST_GUILESS_MAIN(QCoroWaitForTest)
+
+#include "qcorowaitfor.moc"


### PR DESCRIPTION
A patch so that `T` no longer needs to be default constructible when calling `QCoro::waitFor(QCoro::Task<T>)`. Not claiming that this is the best way to do things, but it worked for me. That said I would appreciate any additional testing. I'm only a light user of the QCoro library.

I ended up duplicating some code logic, because I'm not sure if using `std::optional` in all cases could decrease performance. Previously a `T` would always be default constructed, but then RVO should occur when returning the value from `detail::waitFor()` so no additional copy/move would occur. If the default constructor for `T` is cheap, this should have been fine.

With using a `std::optional<T>` though, `T`s default constructor is never called, but I don't think RVO can occur anymore with returning its value from `detail::waitFor()`. I _think_ `T` may be moved to return its value, but this is a corner of C++ I don't have a complete grasp on. 

closes #222 