### PR TITLE
Add QCORO_BUILD_TESTING to allow overriding BUILD_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,16 @@ include(FeatureSummary)
 # Options
 #-----------------------------------------------------------#
 
+
+# Allow QCORO_BUILD_TESTING to override BUILD_TESTING, but default to BUILD_TESTING if not set
+if (DEFINED QCORO_BUILD_TESTING)
+    set(BUILD_TESTING ${QCORO_BUILD_TESTING})
+endif()
+
 option(QCORO_BUILD_EXAMPLES "Build examples" ON)
 add_feature_info(Examples QCORO_BUILD_EXAMPLES "Build examples")
+option(QCORO_BUILD_TESTING "Build QCoro tests" ${BUILD_TESTING})
+add_feature_info(Testing QCORO_BUILD_TESTING "Build QCoro tests")
 option(QCORO_ENABLE_ASAN "Build with AddressSanitizer" OFF)
 add_feature_info(Asan QCORO_ENABLE_ASAN "Build with AddressSanitizer")
 option(QCORO_DISABLE_DEPRECATED_TASK_H "Disable deprecated task.h header" OFF)
@@ -198,7 +206,7 @@ add_subdirectory(qcoro)
 if (QCORO_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
-if (BUILD_TESTING)
+if (QCORO_BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 

--- a/docs/building-and-using.md
+++ b/docs/building-and-using.md
@@ -12,9 +12,9 @@ QCoro uses CMake build system. You can pass following options to the `cmake` com
 QCoro to customize the build:
 
 * `-DQCORO_BUILD_EXAMPLES` - whether to build examples or not (`ON` by default).
+* `-DQCORO_BUILD_TESTING` - whether to build tests or not (defaults to `${BUILD_TESTING}`), can be used to disable building QCoro tests when building QCoro as part of a bigger project which has `BUILD_TESTING` enabled.
 * `-DQCORO_ENABLE_ASAN` - whether to build QCoro with AddressSanitizer (`OFF` by default).
 * `-DBUILD_SHARED_LIBS` - whether to build QCoro as a shared library (`OFF` by default).
-* `-DBUILD_TESTING` - whether to build tests (`ON` by default).
 * `-DUSE_QT_VERSION` - set to `5` or `6` to force a particular version of Qt. When not set the highest available version is used.
 * `-DQCORO_WITH_QTDBUS` - whether to compile support for QtDBus (`ON` by default).
 * `-DQCORO_WITH_QTNETWORK` - whether to compile support for QtNetwork (`ON` by default).


### PR DESCRIPTION
This is useful mostly in larger projects where QCoro is included as a submodule and added using add_subdirectory. Setting this variable allows to disable building QCoro tests, while keeping BUILD_TESTING set to ON, so that the main project's test get built and run.

Fixed #233