### PR TITLE
Use refcount to track when to destroy coroutine

### DIFF
--- a/qcoro/impl/taskfinalsuspend.h
+++ b/qcoro/impl/taskfinalsuspend.h
@@ -30,9 +30,7 @@ inline void TaskFinalSuspend::await_suspend(std::coroutine_handle<Promise> finis
     mAwaitingCoroutines.clear();
 
     // The handle will be destroyed here only if the associated Task has already been destroyed
-    if (promise.setDestroyHandle()) {
-        finishedCoroutine.destroy();
-    }
+    promise.derefCoroutine();
 }
 
 constexpr void TaskFinalSuspend::await_resume() const noexcept {}

--- a/qcoro/qcorotask.h
+++ b/qcoro/qcorotask.h
@@ -196,7 +196,12 @@ public:
 
     bool hasAwaitingCoroutine() const;
 
-    bool setDestroyHandle() noexcept;
+    void derefCoroutine();
+    void refCoroutine();
+    void destroyCoroutine();
+
+protected:
+    explicit TaskPromiseBase();
 
 private:
     friend class TaskFinalSuspend;
@@ -205,7 +210,7 @@ private:
     std::vector<std::coroutine_handle<>> mAwaitingCoroutines;
 
     //! Indicates whether we can destroy the coroutine handle
-    std::atomic<bool> mDestroyHandle{false};
+    std::atomic<uint32_t> mRefCount{0};
 };
 
 //! The promise_type for Task<T>


### PR DESCRIPTION
Instead of a single bool that tells us whether we can destroy the coroutine safely, we now use a ref-count and destroy the coroutine when the count drops to 0. Generally, a coroutine has ref count value of 2 - one is held by the coroutine itself (ensuring it's not deleted until it finishes) and one is held by QCoro::Task, ensuring we can access the coroutine state as long as the corresponding Task exists.

This also opens doors to future enhancements, like SharedTasks that can be safely co_awaited by multiple awaiters.