### PR TITLE
Use QueuedConnection for signals in QCoroNetworkReply

### DIFF
--- a/qcoro/network/qcoronetworkreply.h
+++ b/qcoro/network/qcoronetworkreply.h
@@ -16,13 +16,24 @@ private:
     class WaitForFinishedOperation final {
     public:
         explicit WaitForFinishedOperation(QPointer<QNetworkReply> reply);
+        ~WaitForFinishedOperation();
 
         bool await_ready() const noexcept;
         void await_suspend(std::coroutine_handle<> awaitingCoroutine);
         QNetworkReply *await_resume() const noexcept;
 
     private:
-        QPointer<QNetworkReply> mReply;
+        struct Private;
+        std::unique_ptr<Private> d;
+        // BC: This class used to have a QPointer<QNetworkReply>, which is 2*sizeof(void*),
+        // while std::unique_ptr is only sizeof(void*), so this dummy one is to ensure binary
+        // compatibility of this class.
+        // FIXME: Remove in 1.0
+        // Silly gcc 11, cannot detect the dummy is unused and warns about unused attribute
+        #if __GNUC__ > 11 || defined(__clang__) || defined(_MSC_VER)
+        [[maybe_unused]]
+        #endif
+        void *dummy = nullptr;
     };
 
     friend struct awaiter_type<QNetworkReply *>;


### PR DESCRIPTION
The common pattern (even the one shown in our docs) of using QCoro with QNetworkReply is a local stack-allocated QNAM, making a request and then co_awaiting on the returned QNetworkReply. Once the coroutine is resumed, it likely returns, destroying the QNAM with it. The problem is, that after the coroutine returns, the execution returns back into the code inside QNetworkReply that emitted the signal, which then leads to invalid memory access, since the code has likely been already destroyed alongside the QNAM. Surprisingly, on Linux this does not crash and even ASAN does not detect it (would likely need to compile Qt with ASAN), but Valgrind was able to catch the invalid memory access inside Qt. On Windows this just crashes.

The solution is to use QueuedConnection between QNetworkReply and QCoro, so that we can be sure that by the time our code is called (leading to the destruction of QNAM), no code in the QNAM or its associated classes is being executed, so the destruction is clear.

I had to resort to some hackery to keep the QCoro struct binary compatible, so more cruft to be removed in 1.0.

Fixes #231