### PR TITLE
Make .then() consume the task and defined moved-from task as invalid

### DIFF
--- a/qcoro/impl/connect.h
+++ b/qcoro/impl/connect.h
@@ -20,7 +20,7 @@ requires std::is_invocable_v<Callback> || std::is_invocable_v<Callback, T> || st
 inline void connect(QCoro::Task<T> &&task, QObjectSubclass *context, Callback func) {
     QPointer ctxWatcher = context;
     if constexpr (std::is_same_v<T, void>) {
-        task.then([ctxWatcher, func = std::move(func)]() {
+        std::move(task).then([ctxWatcher, func = std::move(func)]() {
             if (ctxWatcher) {
                 if constexpr (std::is_member_function_pointer_v<Callback>) {
                     (ctxWatcher->*func)();
@@ -30,7 +30,7 @@ inline void connect(QCoro::Task<T> &&task, QObjectSubclass *context, Callback fu
             }
         });
     } else {
-        task.then([ctxWatcher, func = std::move(func)](auto &&value) {
+        std::move(task).then([ctxWatcher, func = std::move(func)](auto &&value) {
             if (ctxWatcher) {
                 if constexpr (std::is_invocable_v<Callback, QObjectSubclass, T>) {
                     (ctxWatcher->*func)(std::forward<decltype(value)>(value));

--- a/qcoro/impl/taskawaiterbase.h
+++ b/qcoro/impl/taskawaiterbase.h
@@ -9,17 +9,23 @@
 #pragma once
 
 #include "../qcorotask.h"
+#include <QDebug>
 
 namespace QCoro::detail
 {
 
 template<typename Promise>
 inline bool TaskAwaiterBase<Promise>::await_ready() const noexcept {
-    return !mAwaitedCoroutine || mAwaitedCoroutine.done();
+    return mAwaitedCoroutine && mAwaitedCoroutine.done();
 }
 
 template<typename Promise>
 inline void TaskAwaiterBase<Promise>::await_suspend(std::coroutine_handle<> awaitingCoroutine) noexcept {
+    if (!mAwaitedCoroutine) {
+        qWarning() << "QCoro::Task: Awaiting a default-constructed or a moved-from QCoro::Task<> - this will hang forever!";
+        return;
+    }
+
     mAwaitedCoroutine.promise().addAwaitingCoroutine(awaitingCoroutine);
 }
 

--- a/qcoro/impl/taskbase.h
+++ b/qcoro/impl/taskbase.h
@@ -76,7 +76,7 @@ inline auto TaskBase<T, TaskImpl, PromiseType>::operator co_await() const noexce
 
     return TaskAwaiter{this->mCoroutine};
 }
-
+/*
 template<typename T, template<typename> class TaskImpl, typename PromiseType>
 template<typename ThenCallback>
 requires (std::is_invocable_v<ThenCallback> || (!std::is_void_v<T> && std::is_invocable_v<ThenCallback, T>))
@@ -84,6 +84,7 @@ inline auto TaskBase<T, TaskImpl, PromiseType>::then(ThenCallback &&callback) & 
     // Provide a custom error handler that simply re-throws the current exception
     return thenImplRef(*this, std::forward<ThenCallback>(callback), [](const auto &) { throw; });
 }
+*/
 
 template<typename T, template<typename> class TaskImpl, typename PromiseType>
 template<typename ThenCallback>
@@ -94,7 +95,7 @@ inline auto TaskBase<T, TaskImpl, PromiseType>::then(ThenCallback &&callback) &&
     // would be destroyed before the thenImpl() is resumed and has a chance to consume/co_await the temporary LazyTask.
     return thenImpl<TaskBase>(std::move(*this), std::forward<ThenCallback>(callback), [](const auto &) { throw; });
 }
-
+/*
 template<typename T, template<typename> class TaskImpl, typename PromiseType>
 template<typename ThenCallback, typename ErrorCallback>
 requires ((std::is_invocable_v<ThenCallback> || (!std::is_void_v<T> && std::is_invocable_v<ThenCallback, T>)) &&
@@ -102,7 +103,7 @@ requires ((std::is_invocable_v<ThenCallback> || (!std::is_void_v<T> && std::is_i
 inline auto TaskBase<T, TaskImpl, PromiseType>::then(ThenCallback &&callback, ErrorCallback &&errorCallback) & {
     return thenImplRef(*this, std::forward<ThenCallback>(callback), std::forward<ErrorCallback>(errorCallback));
 }
-
+*/
 template<typename T, template<typename> class TaskImpl, typename PromiseType>
 template<typename ThenCallback, typename ErrorCallback>
 requires ((std::is_invocable_v<ThenCallback> || (!std::is_void_v<T> && std::is_invocable_v<ThenCallback, T>)) &&

--- a/qcoro/qcorotask.h
+++ b/qcoro/qcorotask.h
@@ -388,18 +388,21 @@ public:
      * result of the then() action can be co_awaited, if desired. If the callback
      * returns an awaitable (Task<R>) then the result of then is the awaitable.
      */
+    /*
     template<typename ThenCallback>
     requires (std::is_invocable_v<ThenCallback> || (!std::is_void_v<T> && std::is_invocable_v<ThenCallback, T>))
     auto then(ThenCallback &&callback) &;
+    */
     template<typename ThenCallback>
     requires (std::is_invocable_v<ThenCallback> || (!std::is_void_v<T> && std::is_invocable_v<ThenCallback, T>))
     auto then(ThenCallback &&callback) &&;
 
-
+    /*
     template<typename ThenCallback, typename ErrorCallback>
     requires ((std::is_invocable_v<ThenCallback> || (!std::is_void_v<T> && std::is_invocable_v<ThenCallback, T>)) &&
                std::is_invocable_v<ErrorCallback, const std::exception &>)
     auto then(ThenCallback &&callback, ErrorCallback &&errorCallback) &;
+    */
     template<typename ThenCallback, typename ErrorCallback>
     requires ((std::is_invocable_v<ThenCallback> || (!std::is_void_v<T> && std::is_invocable_v<ThenCallback, T>)) &&
                std::is_invocable_v<ErrorCallback, const std::exception &>)

--- a/qcoro/qml/qcoroqmltask.cpp
+++ b/qcoro/qml/qcoroqmltask.cpp
@@ -67,7 +67,7 @@ void QmlTask::then(QJSValue func) {
         return;
     }
 
-    d->task->then([func = std::move(func)](const QVariant &result) mutable -> void {
+    std::move(*d->task).then([func = std::move(func)](const QVariant &result) mutable -> void {
         auto jsval = getEngineForValue(func)->toScriptValue(result);
         func.call({jsval});
     });
@@ -79,7 +79,7 @@ QmlTaskListener *QmlTask::await(const QVariant &intermediateValue)
     if (!intermediateValue.isNull()) {
         listener->setValue(QVariant(intermediateValue));
     }
-    d->task->then([listener](auto &&value) {
+    std::move(*d->task).then([listener](auto &&value) {
         if (listener) {
             listener->setValue(std::move(value));
         }

--- a/qcoro/qml/qcoroqmltask.h
+++ b/qcoro/qml/qcoroqmltask.h
@@ -42,7 +42,7 @@ public:
      */
     template <typename T>
     QmlTask(QCoro::Task<T> &&task) : QmlTask(
-        task.then([](T &&result) -> QCoro::Task<QVariant> {
+        std::move(task).then([](T &&result) -> QCoro::Task<QVariant> {
             co_return QVariant::fromValue(std::forward<T>(result));
         }))
     {
@@ -66,7 +66,7 @@ public:
      */
     template <typename T = void>
     QmlTask(QCoro::Task<> &&task) : QmlTask(
-        task.then([]() -> QCoro::Task<QVariant> {
+        std::move(task).then([]() -> QCoro::Task<QVariant> {
             co_return QVariant();
         }))
     {

--- a/qcoro/quick/qcoroimageprovider.cpp
+++ b/qcoro/quick/qcoroimageprovider.cpp
@@ -25,7 +25,7 @@ QQuickImageResponse *ImageProvider::requestImageResponse(const QString &id, cons
 
     auto *response = new QCoroImageResponse();
 
-    task.then([response](QImage &&image) {
+    std::move(task).then([response](QImage &&image) {
         response->reportFinished(std::move(image));
     });
 

--- a/tests/testlibs/testobject.cpp
+++ b/tests/testlibs/testobject.cpp
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: MIT
 
 #include "testobject.h"
+#include <chrono>
 
 using namespace QCoro;
 
 TestContext::TestContext(QEventLoop &el) : mEventLoop(&el) {
     mEventLoop->setProperty("testFinished", false);
     mEventLoop->setProperty("shouldNotSuspend", false);
+    mEventLoop->setProperty("expectTimeout", false);
 }
 
 TestContext::TestContext(TestContext &&other) noexcept {
@@ -29,4 +31,13 @@ TestContext &TestContext::operator=(TestContext &&other) noexcept {
 
 void TestContext::setShouldNotSuspend() {
     mEventLoop->setProperty("shouldNotSuspend", true);
+}
+
+void TestContext::setTimeout(std::chrono::milliseconds timeout) {
+    auto *timer = qobject_cast<QTimer *>(mEventLoop->property("timeout").value<QObject *>());
+    timer->start(timeout);
+}
+
+void TestContext::expectTimeout() {
+    mEventLoop->setProperty("expectTimeout", true);
 }


### PR DESCRIPTION
The .then() continuation will consume the task (move from it), leaving the task in a moved-from state.

Additionally, a moved-from state is now well-defined (to be identical to default-constructed) as the task not every being resumed.

This is an initial exploration for issue #243 