### PR TITLE
AsyncGenerator: implement `await_transform` in promise type

### DIFF
--- a/qcoro/CMakeLists.txt
+++ b/qcoro/CMakeLists.txt
@@ -24,9 +24,11 @@ add_qcoro_library(
         concepts_p.h
         coroutine.h
         macros_p.h
+        mixins_p.h
         waitoperationbase_p.h
         impl/connect.h
         impl/lazytask.h
+        impl/mixins.h
         impl/task.h
         impl/taskawaiterbase.h
         impl/taskbase.h

--- a/qcoro/impl/mixins.h
+++ b/qcoro/impl/mixins.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 Daniel Vrátil <dvratil@kde.org>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+namespace QCoro::detail {
+
+template<typename T, typename Awaiter>
+inline auto AwaitTransformMixin::await_transform(T &&value) {
+    return Awaiter{std::forward<T>(value)};
+}
+
+template<Awaitable T>
+inline auto && AwaitTransformMixin::await_transform(T &&awaitable) {
+    return std::forward<T>(awaitable);
+}
+
+template<Awaitable T>
+inline auto &AwaitTransformMixin::await_transform(T &awaitable) {
+    return awaitable;
+}
+
+}

--- a/qcoro/impl/taskpromisebase.h
+++ b/qcoro/impl/taskpromisebase.h
@@ -27,21 +27,6 @@ inline auto TaskPromiseBase::final_suspend() const noexcept {
     return TaskFinalSuspend{mAwaitingCoroutines};
 }
 
-template<typename T, typename Awaiter>
-inline auto TaskPromiseBase::await_transform(T &&value) {
-    return Awaiter{std::forward<T>(value)};
-}
-
-template<Awaitable T>
-inline auto && TaskPromiseBase::await_transform(T &&awaitable) {
-    return std::forward<T>(awaitable);
-}
-
-template<Awaitable T>
-inline auto &TaskPromiseBase::await_transform(T &awaitable) {
-    return awaitable;
-}
-
 inline void TaskPromiseBase::addAwaitingCoroutine(std::coroutine_handle<> awaitingCoroutine) {
     mAwaitingCoroutines.push_back(awaitingCoroutine);
 }

--- a/qcoro/mixins_p.h
+++ b/qcoro/mixins_p.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025 Daniel Vrátil <dvratil@kde.org>
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+namespace QCoro::detail {
+
+template<typename T>
+struct awaiter_type;
+
+template<typename T>
+using awaiter_type_t = typename awaiter_type<T>::type;
+
+class AwaitTransformMixin {
+public:
+    //! Called by `co_await` to obtain an Awaitable for type \c T.
+    /*!
+     * When co_awaiting on a value of type \c T, the type \c T must an Awaitable. To allow
+     * to co_await even on types that are not Awaitable (e.g. 3rd party types like QNetworkReply),
+     * C++ allows promise_type to provide \c await_transform() function that can transform
+     * the type \c T into an Awaitable. This is a very powerful mechanism in C++ coroutines.
+     *
+     * For types \c T for which there is no valid await_transform() overload, the C++ attempts
+     * to use those types directly as Awaitables. This is a perfectly valid scenario in cases
+     * when co_awaiting a type that implements the neccessary Awaitable interface.
+     *
+     * In our implementation, the await_transform() is overloaded only for Qt types for which
+     * a specialiation of the \c QCoro::detail::awaiter_type template class exists. The
+     * specialization returns type of the Awaiter for the given type \c T.
+     */
+    template<typename T, typename Awaiter = QCoro::detail::awaiter_type_t<std::remove_cvref_t<T>>>
+    auto await_transform(T &&value);
+
+    //! If the type T is already an awaitable (including Task or LazyTask), then just forward it as it is.
+    template<Awaitable T>
+    auto && await_transform(T &&awaitable);
+
+    //! \copydoc template<Awaitable T> QCoro::TaskPromiseBase::await_transform(T &&)
+    template<Awaitable T>
+    auto &await_transform(T &awaitable);
+};
+
+} // namespace QCoro::detail
+
+#include "impl/mixins.h"

--- a/qcoro/qcoroasyncgenerator.h
+++ b/qcoro/qcoroasyncgenerator.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "coroutine.h"
+#include "mixins_p.h"
 
 #include <iterator>
 #include <exception>
@@ -25,7 +26,7 @@ class AsyncGeneratorIterator;
 class AsyncGeneratorYieldOperation;
 class AsyncGeneratorAdvanceOperation;
 
-class AsyncGeneratorPromiseBase {
+class AsyncGeneratorPromiseBase : public AwaitTransformMixin {
 public:
     AsyncGeneratorPromiseBase() noexcept = default;
     AsyncGeneratorPromiseBase(const AsyncGeneratorPromiseBase &) = delete;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -115,7 +115,7 @@ qcoro_add_test(qcorolazytask)
 qcoro_add_test(testconstraints)
 qcoro_add_test(qfuture LINK_LIBRARIES Qt${QT_VERSION_MAJOR}::Concurrent)
 qcoro_add_test(qcorogenerator)
-qcoro_add_test(qcoroasyncgenerator)
+qcoro_add_test(qcoroasyncgenerator LINK_LIBRARIES QCoro${QT_VERSION_MAJOR}Network Qt${QT_VERSION_MAJOR}::Network)
 qcoro_add_test(qcorowaitfor)
 
 if (QCORO_WITH_QTDBUS)


### PR DESCRIPTION
This allows directly `co_await`ing various QCoro types without the use of the `qCoro()` wrapper in AsyncGenerator coroutines. We already have this behavior in `QCoro::Task` coroutines, so its confusing that `auto *reply = co_await nam.get(...)` would work in QCoro::Task but not in an AsyncGenerator.

Fixes #292.