### PR TITLE
Use dbus-run-session to run D-Bus tests instead of dbus-launch

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,9 +64,10 @@ function(qcoro_add_dbus_test _name)
     target_compile_definitions(test-${_name} PRIVATE TESTDBUSSERVER_EXECUTABLE=\"$<TARGET_FILE:testdbusserver>\")
     if (APPLE)
         # On MacOS dbus-launch doesn't work, so we rely on the session dbus running
+        # TODO: check whether dbus-run-session works
         add_test(NAME test-${_name} COMMAND test-${_name})
     else()
-        add_test(NAME test-${_name} COMMAND dbus-launch $<TARGET_FILE:test-${_name}>)
+        add_test(NAME test-${_name} COMMAND dbus-run-session $<TARGET_FILE:test-${_name}>)
     endif()
     _enable_supressions(${_name})
 endfunction()


### PR DESCRIPTION
`dbus-run-session` spawns a session that gets terminated automatically after the execution of the command. It is a simpler way compared to `dbus-launch`, which relies on the X11 tolaunching (which would explain why it is not used on macOS, as the comment says).

Hence, use `dbus-run-session` instead of `dbus-launch` to run each D-Bus test. Keep the existing macOS behaviour as-is for now, adding a comment to test using `dbus-run-session` in the future.