### PR TITLE
Fix BUILD_INTERFACE expression

### DIFF
--- a/cmake/AddQCoroLibrary.cmake
+++ b/cmake/AddQCoroLibrary.cmake
@@ -124,7 +124,7 @@ function(add_qcoro_library)
         ${target_include_interface} $<BUILD_INTERFACE:${QCORO_SOURCE_DIR}/qcoro>
         ${target_include_interface} $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         ${target_include_interface} $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-        ${target_include_interface} $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>/QCoro
+        ${target_include_interface} $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/QCoro>
         ${target_include_interface} $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         ${target_include_interface} $<INSTALL_INTERFACE:${QCORO_INSTALL_INCLUDEDIR}>
         ${target_include_interface} $<INSTALL_INTERFACE:${QCORO_INSTALL_INCLUDEDIR}/qcoro>


### PR DESCRIPTION
Currently this evaluates to /QCoro for !BUILD_INTERFACE, breaking building against the library

Amends 64f2a5510e3d74cc9e9db7308a60e14c094ab7e0