### PR TITLE
Register QCoro as a proper QML plugin with qmldir and qmltypes

### DIFF
--- a/cmake/AddQCoroLibrary.cmake
+++ b/cmake/AddQCoroLibrary.cmake
@@ -79,7 +79,7 @@ function(add_qcoro_library)
     endfunction()
 
     set(params INTERFACE NO_CMAKE_CONFIG)
-    set(oneValueArgs NAME)
+    set(oneValueArgs NAME QML_MODULE)
     set(multiValueArgs SOURCES CAMELCASE_HEADERS HEADERS QCORO_LINK_LIBRARIES QT_LINK_LIBRARIES)
 
     cmake_parse_arguments(LIB "${params}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -105,13 +105,24 @@ function(add_qcoro_library)
         OUTPUT qt_LIBS
     )
 
-    # TODO: How is it done in Qt?
-    # We want to export target QCoro5::Network but so far we are exporting
-    # QCoro5::QCoro5Network :shrug:
     add_library(${target_name} ${target_interface})
     add_library(${QCORO_TARGET_PREFIX}::${LIB_NAME} ALIAS ${target_name})
+
     if (LIB_SOURCES)
         target_sources(${target_name} PRIVATE ${LIB_SOURCES})
+    endif()
+    if (LIB_QML_MODULE)
+        if (NOT DEFINED QT_QML_INSTALL_DIR)
+            ecm_query_qt(QT_QML_INSTALL_DIR QT_INSTALL_QML)
+        endif()
+        qt_add_qml_module(
+            ${target_name}
+            URI ${LIB_QML_MODULE}
+            OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${LIB_QML_MODULE}"
+            VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+            TYPEINFO "${LIB_QML_MODULE}.qmltypes"
+            OUTPUT_TARGETS _qml_module_targets
+        )
     endif()
 
     target_include_directories(
@@ -141,7 +152,7 @@ function(add_qcoro_library)
     )
 
     set_target_defaults(${target_name})
-    
+
     if (NOT LIB_INTERFACE)
         set_target_properties(
             ${target_name}
@@ -209,9 +220,18 @@ function(add_qcoro_library)
     )
 
     install(
-        TARGETS ${target_name}
+        TARGETS ${target_name} ${_qml_module_targets}
         EXPORT ${target_name}Targets
     )
+    if (LIB_QML_MODULE AND TARGET "${target_name}plugin")
+        install(
+            TARGETS "${target_name}plugin"
+            EXPORT ${target_name}Targets
+            LIBRARY DESTINATION "${QT_QML_INSTALL_DIR}/${LIB_QML_MODULE}"
+            ARCHIVE DESTINATION "${QT_QML_INSTALL_DIR}/${LIB_QML_MODULE}"
+            RUNTIME DESTINATION "${QT_QML_INSTALL_DIR}/${LIB_QML_MODULE}"
+        )
+    endif()
     install(
         FILES ${source_HEADERS}
         DESTINATION ${QCORO_INSTALL_INCLUDEDIR}/qcoro/
@@ -255,4 +275,17 @@ function(add_qcoro_library)
         DESTINATION "${ECM_MKSPECS_INSTALL_DIR}"
         COMPONENT Devel
     )
+
+    if (LIB_QML_MODULE)
+        # Install QML module files (qmldir, qmltypes, plugin) to the QML import path
+        set(_qml_output_dir "${CMAKE_CURRENT_BINARY_DIR}/${LIB_QML_MODULE}")
+        if (NOT DEFINED QT_QML_INSTALL_DIR)
+            ecm_query_qt(QT_QML_INSTALL_DIR QT_INSTALL_QML)
+        endif()
+        install(
+            FILES "${_qml_output_dir}/qmldir"
+                  "${_qml_output_dir}/${LIB_QML_MODULE}.qmltypes"
+            DESTINATION "${QT_QML_INSTALL_DIR}/${LIB_QML_MODULE}"
+        )
+    endif()
 endfunction()

--- a/docs/reference/qml/index.md
+++ b/docs/reference/qml/index.md
@@ -5,8 +5,7 @@ SPDX-License-Identifier: GFDL-1.3-or-later
 
 # QML Module
 
-The `QML` module contains coroutine-friendly wrappers for
-[QtQml][qtdoc-qml] classes.
+The QCoro `QML` module contains coroutine-friendly wrappers for [QtQml][qtdoc-qml] classes.
 
 ## CMake Usage
 
@@ -22,16 +21,5 @@ target_link_libraries(my-target QCoro::Qml)
 QT += QCoroQml
 ```
 
-## Type registration
-
-To use types defined in QCoroQml, you need to call the `QCoro::Qml::registerTypes` function before loading the QML.
-
-```C++
-int main() {
-    ...
-    QCoro::Qml::registerTypes();
-    ...
-}
-```
 
 [qtdoc-qml]: https://doc.qt.io/qt-6/qml-index.html

--- a/docs/reference/qml/qmltask.md
+++ b/docs/reference/qml/qmltask.md
@@ -18,7 +18,6 @@ int main()
 {
     ...
     qmlRegisterType<Example>("io.me.qmlmodule", 1, 0, "Example");
-    QCoro::Qml::registerTypes();
     ...
 }
 

--- a/qcoro/qml/CMakeLists.txt
+++ b/qcoro/qml/CMakeLists.txt
@@ -6,6 +6,7 @@
 add_qcoro_library(
     NAME Qml
     INCLUDEDIR Qml
+    QML_MODULE QCoro
     SOURCES
         qcoroqmltask.cpp
         qcoroqml.cpp

--- a/qcoro/qml/qcoroqml.h
+++ b/qcoro/qml/qcoroqml.h
@@ -10,6 +10,7 @@
 
 namespace QCoro::Qml {
 
+[[deprecated("Use 'import QCoro' in QML instead")]]
 QCOROQML_EXPORT void registerTypes();
 
 }

--- a/qcoro/qml/qcoroqmltask.h
+++ b/qcoro/qml/qcoroqmltask.h
@@ -7,6 +7,7 @@
 #include <QCoro/QCoroTask>
 #include <QJSValue>
 #include <QJSEngine>
+#include <QtQml/qqmlregistration.h>
 
 #include "qcoroqml_export.h"
 
@@ -22,6 +23,7 @@ class QmlTaskListener;
 //! QML type that allows to react to asynchronous computations from QML
 struct QCOROQML_EXPORT QmlTask {
     Q_GADGET
+    QML_VALUE_TYPE(task)
 
 public:
     // Just for Q_DECLARE_METATYPE to be happy
@@ -98,6 +100,7 @@ private:
 
 class QmlTaskListener : public QObject {
     Q_OBJECT
+    QML_ANONYMOUS
     Q_PROPERTY(QVariant value READ value NOTIFY valueChanged)
 
 public:

--- a/tests/qcoroqmltask.cpp
+++ b/tests/qcoroqmltask.cpp
@@ -68,11 +68,8 @@ private:
             return new QmlObject();
         });
 
-        QCoro::Qml::registerTypes();
-
         engine.loadData(R"(
 import qcoro.test 0.1
-import QCoro 0
 import QtQuick 2.7
 
 QtObject {
@@ -119,7 +116,7 @@ QtObject {
             running = false;
         });
 
-        // Crash the test in case the timeout was reachaed without the callback being called
+        // Crash the test in case the timeout was reached without the callback being called
         connect(timeout, &QTimer::timeout, this, [&]() {
 #if defined(Q_CC_CLANG) && defined(Q_OS_WINDOWS)
             running = false;


### PR DESCRIPTION
This makes QCoro::Qml::registerTypes() obsolete, since the types are registered automatically. The qmldir and .qmltypes files ensure that LSPs can autocomplete methods/properties on the types.